### PR TITLE
Added RGB LED for Lolin S3 Boards

### DIFF
--- a/AcidBanger.ino
+++ b/AcidBanger.ino
@@ -295,13 +295,25 @@ static const byte button_pins[ButLast] = {
 
 
 static void send_midi_noteon(byte chan, byte note, byte vol) {
-  // MIDI.sendNoteOn(note, vol, chan);
+#ifdef MIDI_VIA_SERIAL  
+  MIDI.sendNoteOn(note, vol, chan);
+#endif
+#ifdef MIDI_VIA_SERIAL2  
+  MIDI2.sendNoteOn(note, vol, chan);
+#endif
   handleNoteOn( chan, note, vol) ;
 }
+
 static void send_midi_noteoff(byte chan, byte note) {
-  //MIDI.sendNoteOn(note, 0, chan);
+#ifdef MIDI_VIA_SERIAL  
+  MIDI.sendNoteOn(note, 0, chan);
+#endif
+#ifdef MIDI_VIA_SERIAL2  
+  MIDI2.sendNoteOn(note, 0, chan);
+#endif
   handleNoteOff( chan, note, 0) ;
 }
+
 static void init_midi() {
   //  Serial.begin(115200);
   //  MIDI.begin(MIDI_CHANNEL_OMNI);
@@ -476,11 +488,20 @@ void sequencer_step(byte step) {
   }
   if (step % 4 == 0 || step == 1) {
     digitalWrite(LED_BUILTIN, HIGH);
+    #ifdef LOLIN_RGB
+      pixels.setPixelColor(0, pixels.Color(rand() % 32, rand() % 32, rand() % 32));
+      pixels.show();
+    #endif
+
 #ifdef DEBUG_JUKEBOX
     DEBUG(step);
 #endif
   }  else {
     digitalWrite(LED_BUILTIN, LOW);
+    #ifdef LOLIN_RGB
+      pixels.setPixelColor(0, pixels.Color(0,0,0));
+      pixels.show();
+    #endif
   }
 }
 

--- a/AcidBox.ino
+++ b/AcidBox.ino
@@ -36,6 +36,13 @@
 #include <MIDI.h>
 #endif
 
+#ifdef LOLIN_RGB
+  #include <Adafruit_NeoPixel.h>
+  #define LED 38
+  #define NUMPIXELS 1
+  Adafruit_NeoPixel pixels(NUMPIXELS, LED, NEO_GRB + NEO_KHZ800);
+#endif
+
 #ifdef MIDI_VIA_SERIAL
 // default settings for Hairless midi is 115200 8-N-1
 struct CustomBaudRateSettings : public MIDI_NAMESPACE::DefaultSerialSettings {

--- a/config.h
+++ b/config.h
@@ -11,6 +11,8 @@
 //#define USE_INTERNAL_DAC      // use this for testing, SOUND QUALITY SACRIFICED: NOISY 8BIT STEREO
 //#define NO_PSRAM              // if you don't have PSRAM on your board, then use this define, but REVERB TO BE SACRIFICED, ONE SMALL DRUM KIT SAMPLES USED 
 
+#define LOLIN_RGB               // Flashes the LOLIN S3 buildin RGB-LED
+
 //#define DEBUG_ON              // note that debugging eats ticks initially belonging to real-time tasks, so sound output will be spoild in most cases, turn it off for production build
 //#define DEBUG_MASTER_OUT      // serial monitor plotter will draw the output waveform
 //#define DEBUG_SAMPLER


### PR DESCRIPTION
I added the Code to flash the RGB-LED on Lolin S3 boards in random colors to the beat. Also your code for Midi-out is included in this fork.